### PR TITLE
Fixes pom file version info

### DIFF
--- a/broker-store-commons/pom.xml
+++ b/broker-store-commons/pom.xml
@@ -8,8 +8,8 @@
     <modelVersion>4.0.0</modelVersion>
     <artifactId>broker-store-commons</artifactId>
     <properties>
-        <brokerVersion>2.6.0</brokerVersion>
-        <brokerTestVersion>2.6.0</brokerTestVersion>
+        <brokerVersion>2.5.0</brokerVersion>
+        <brokerTestVersion>2.5.0</brokerTestVersion>
         <jacoco-measurement-instructions>0.8867</jacoco-measurement-instructions>
         <jacoco-measurement-branches>0.8333</jacoco-measurement-branches>
         <jacoco-measurement-lines>0.8707</jacoco-measurement-lines>

--- a/hdfs-broker-store/pom.xml
+++ b/hdfs-broker-store/pom.xml
@@ -14,11 +14,17 @@
         <jacoco-measurement-lines>0.6458</jacoco-measurement-lines>
         <jacoco-measurement-classes>1.0000</jacoco-measurement-classes>
     </properties>
+    <repositories>
+        <repository>
+            <id>cloudera</id>
+            <url>https://repository.cloudera.com/artifactory/cloudera-repos/</url>
+        </repository>
+    </repositories>
     <dependencies>
         <dependency>
             <groupId>org.trustedanalytics.servicebroker.repository</groupId>
             <artifactId>broker-store-commons</artifactId>
-            <version>0.4.3</version>
+            <version>0.5.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.hadoop</groupId>

--- a/sql-broker-store/pom.xml
+++ b/sql-broker-store/pom.xml
@@ -20,7 +20,7 @@
         <dependency>
             <groupId>org.trustedanalytics.servicebroker.repository</groupId>
             <artifactId>broker-store-commons</artifactId>
-            <version>0.4.3</version>
+            <version>0.5.0</version>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>

--- a/zookeeper-broker-store/pom.xml
+++ b/zookeeper-broker-store/pom.xml
@@ -17,7 +17,7 @@
         <dependency>
             <groupId>org.trustedanalytics.servicebroker.repository</groupId>
             <artifactId>broker-store-commons</artifactId>
-            <version>0.4.3</version>
+            <version>0.5.0</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>


### PR DESCRIPTION
1. Change broker-store-commons version to 0.5.0
   As of aa136b5, the master branch version is 0.5.0
2. Change spring-boot-cf-service-broker to 2.5.0
   The current version is 2.5.0
   https://github.com/cloudfoundry-community/spring-boot-cf-service-broker/blob/master/build.gradle#L18
3. Add CDH5 Maven repository
